### PR TITLE
Проблем с абсолютните URL-и

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    siteUrl: process.env.SITE_URL || "https://tuesfest.bg",
+    siteUrl: process.env.SITE_URL || "https://2023.tuesfest.bg",
     generateRobotsTxt: true,
     sitemapSize: 7000,
     exclude: ['/iskren', '/api', '/api/*'],

--- a/public/logo/motto.svg
+++ b/public/logo/motto.svg
@@ -4,7 +4,7 @@
     <style>
       @font-face {
           font-family: OriginTechDemoRegular, 'Origin Tech Demo';
-          src: url('https://tuesfest.bg/fonts/origintech.ttf');
+          src: url('https://2023.tuesfest.bg/fonts/origintech.ttf');
       }
       .cls-1 {
         fill: #a47bf5;

--- a/public/test/data/projects.json
+++ b/public/test/data/projects.json
@@ -2,13 +2,13 @@
     {
         "id": 1,
         "name": "Sputnik",
-        "thumbnail": "https://tuesfest.bg/happy/iskren.jpg",
+        "thumbnail": "https://2023.tuesfest.bg/happy/iskren.jpg",
         "category": "EMBEDDED"
     },
     {
         "id": 2,
         "name": "Sputnik 2",
-        "thumbnail": "https://tuesfest.bg/happy/iskren.jpg",
+        "thumbnail": "https://2023.tuesfest.bg/happy/iskren.jpg",
         "category": "EMBEDDED"
     }
 ]

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -83,19 +83,19 @@ export const metadata = {
 		description:
 			'TUES Fest 2023 - ден на отворените врати на ТУЕС и изложение на ученически проекти. София Тех Парк - 23 април 2023.',
 		creator: '@tuesfest',
-		images: ['https://tuesfest.bg/logo/motto.png'],
+		images: ['https://2023.tuesfest.bg/logo/motto.png'],
 	},
 	archives: ['https://2022.tuesfest.bg'],
-	assets: ['https://tuesfest.bg/favicon.png', 'https://tuesfest.bg/logo/motto.png', 'https://tuesfest.bg/assets'],
+	assets: ['https://2023.tuesfest.bg/favicon.png', 'https://2023.tuesfest.bg/logo/motto.png', 'https://2023.tuesfest.bg/assets'],
 	openGraph: {
 		title: 'TUES Fest 2023',
 		description:
 			'TUES Fest 2023 - ден на отворените врати на ТУЕС и изложение на ученически проекти. София Тех Парк - 23 април 2023.',
-		url: 'https://tuesfest.bg',
+		url: 'https://2023.tuesfest.bg',
 		siteName: 'TUES Fest 2023',
 		images: [
 			{
-				url: 'https://tuesfest.bg/logo/motto.png',
+				url: 'https://2023.tuesfest.bg/logo/motto.png',
 			},
 		],
 		locale: 'bg-BG',

--- a/src/app/projects/[projectId]/page.tsx
+++ b/src/app/projects/[projectId]/page.tsx
@@ -41,7 +41,7 @@ export type Project = {
 };
 
 const getProject = async (id: string) => {
-	const res = await fetch(`https://tuesfest.bg/data/project/${id}.json`);
+	const res = await fetch(`https://2023.tuesfest.bg/data/project/${id}.json`);
 
 	if (!res.ok) {
 		// This will activate the closest `error.js` Error Boundary
@@ -81,7 +81,7 @@ export async function generateMetadata({ params }: { params: { projectId: string
 		openGraph: {
 			title: `${project.name} | TUES Fest 2023`,
 			description: project.description,
-			url: `https://tuesfest.bg/projects/${project.id}`,
+			url: `https://2023.tuesfest.bg/projects/${project.id}`,
 			siteName: 'TUES Fest 2023',
 			images: images?.map((image) => ({
 				url: image.url,

--- a/src/app/projects/layout.tsx
+++ b/src/app/projects/layout.tsx
@@ -33,16 +33,16 @@ export const metadata = {
 		description:
 			'Тук може да откриете проектите на учениците на ТУЕС. Тази година над 120 проекта ще бъдат представени само на 23 април в София Тех Парк - форум Джон Атанасов.',
 		creator: '@tuesfest',
-		images: ['https://tuesfest.bg/logo/motto.png'],
+		images: ['https://2023.tuesfest.bg/logo/motto.png'],
 	},
-	assets: ['https://tuesfest.bg/favicon.png', 'https://tuesfest.bg/logo/motto.png', 'https://tuesfest.bg/assets'],
+	assets: ['https://2023.tuesfest.bg/favicon.png', 'https://2023.tuesfest.bg/logo/motto.png', 'https://2023.tuesfest.bg/assets'],
 	openGraph: {
 		title: 'Проекти | TUES Fest 2023',
 		description:
 			'Тук може да откриете проектите на учениците на ТУЕС. Тази година над 120 проекта ще бъдат представени само на 23 април в София Тех Парк - форум Джон Атанасов.',
-		url: `https://tuesfest.bg/projects`,
+		url: `https://2023.tuesfest.bg/projects`,
 		siteName: 'TUES Fest 2023',
-		images: ['https://tuesfest.bg/logo/motto.png'],
+		images: ['https://2023.tuesfest.bg/logo/motto.png'],
 		locale: 'bg-BG',
 		type: 'website',
 	},

--- a/src/partials/projects/Projects.tsx
+++ b/src/partials/projects/Projects.tsx
@@ -20,7 +20,7 @@ const getProjects = async (category: string): Promise<Project[]> => {
 
 	// load from static file in public directory
 
-	const url = `https://tuesfest.bg/data/projects${category === 'all' ? '' : '/' + category}.json`;
+	const url = `https://2023.tuesfest.bg/data/projects${category === 'all' ? '' : '/' + category}.json`;
 	console.warn(url);
 
 	const res = await fetch(url);


### PR DESCRIPTION
Архивът, хостнат на [2023.tuesfest.bg](https://2023.tuesfest.bg) използва URL-и от `https://tuesfest.bg` origin-а, които вече са 404. В резултат много неща се чупят в архива:

![image](https://github.com/user-attachments/assets/1967514b-ab32-4215-8f9e-075ed2eddfaf)

(creds: митко, който го забеляза :heart:)